### PR TITLE
Ray 2D and 3D Override Option

### DIFF
--- a/python/aubellhop/readers.py
+++ b/python/aubellhop/readers.py
@@ -951,7 +951,15 @@ def read_arrivals(fname: str) -> pd.DataFrame:
     return reader.read_arrivals()
 
 def read_rays(fname: str, is_2d: Optional[bool] = None) -> pd.DataFrame:
-    """Read Bellhop rays file and parse data into a high level data structure"""
+    """Read Bellhop rays file and parse data into a high level data structure
+
+    Args:
+        fname: file path
+        is_2d: if True, read as 2D rays; if False, read as 3D rays; if None, auto-detect using header
+
+    Raises:
+        ValueError: if is_2d is not provided and parsing file header fails.
+    """
     reader = BellhopOutputReader(fname)
     return reader.read_rays(is_2d = is_2d)
 


### PR DESCRIPTION
Hi Adelaide University team,

Appreciate this consolidation effort for tooling around bellhop. One item I have run into while using the python tools is the requirement for naming ray files as "BELLHOP-" or "BELLHOP3D-". I am proposing a change to provide an optional `is_2d` boolean argument that overrides the name convention of the file in case the file has a different header name. While I was in there I also added a `ValueError` to give a clearer message to the user on why parsing failed as it took me a bit to track down why my reads were failing. 

Tim