### PR TITLE
Fix ty type checker failing with unresolved-import errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ lintp:
 
 typep: uvsync
 	@echo "Type checking with TY..."
-	uvx ty check python/$(PKGNAME) --exclude python/$(PKGNAME)/plotutils.py
+	uv run ty check python/$(PKGNAME) --exclude python/$(PKGNAME)/plotutils.py
 
 lintf:
 	@echo "Linting fortran with FORTITUDE..."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dev = [
     "sphinxcontrib-mermaid",
     "quarto>=0.1.0",
     "fortitude-lint",
+    "ty",
 ]
 
 

--- a/python/aubellhop/pyplot.py
+++ b/python/aubellhop/pyplot.py
@@ -122,8 +122,8 @@ def pyplot_env2d(
     _pyplt.xlabel('Range'+range_unit)
     _pyplt.ylabel('Depth (m)')
     ax.yaxis.set_inverted(True)
-    _pyplt.xlim([min_x - mgn_x, max_x + mgn_x])
-    _pyplt.ylim([max_y + mgn_y, min_y - mgn_y])
+    _pyplt.xlim((min_x - mgn_x, max_x + mgn_x))
+    _pyplt.ylim((max_y + mgn_y, min_y - mgn_y))
 
 def pyplot_env3d(env: Environment, surface_color: str = 'dodgerblue', bottom_color: str = 'peru', source_color: str = 'orangered', receiver_color: str = 'midnightblue',
                receiver_plot: bool | None = None, ax: Any | None = None, **kwargs: Any) -> None:


### PR DESCRIPTION
ty tightened rules and now reports unresolved-import for numpy/pandas/
matplotlib when run via uvx (which creates an isolated env without the
project venv). Fix by adding ty to dev dependencies and switching from
uvx to uv run so ty executes inside the project venv where those
packages are installed.

https://claude.ai/code/session_018yqNJgg4c8pQe8RTV7VpGd