### PR TITLE
Fix publish job running on PyPI even when a wheel build fails

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -174,8 +174,10 @@ jobs:
     environment: pypi
     permissions:
       id-token: write  # Required for PyPI trusted publishing
-    # Only publish on tagged releases
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    # Only publish on tagged releases, and only if every build job succeeded
+    # (a job's own `if:` replaces the implicit `needs` success check, so this
+    # must be spelled out explicitly or a failed platform won't block publish)
+    if: success() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
 
     steps:
       - name: Download all artifacts


### PR DESCRIPTION
The publish job's explicit `if:` condition silently overrode the
implicit success() check that `needs: [build_wheels, build_sdist]`
normally provides, so a failed platform in the build_wheels matrix
(fail-fast: false) did not stop the release from being pushed to
PyPI. Add success() back into the condition explicitly.

https://claude.ai/code/session_018yqNJgg4c8pQe8RTV7VpGd