### PR TITLE
Fix make clean deleting tracked images in publications/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,8 +109,8 @@ clean: coverage-clean
 	-rm -f bin/*.exe
 	-rm -rf doc
 	find . -name '*.dSYM' -exec rm -r {} +
-	find . -name '*.png'  -exec rm -r {} +
-	find . -name '*.eps'  -exec rm -r {} +
+	find . -name '*.png' -not -path './publications/*' -exec rm -r {} +
+	find . -name '*.eps' -not -path './publications/*' -exec rm -r {} +
 	find . -name '*.mod'  -exec rm -r {} +
 	find . -name '*.grn'  -exec rm -r {} +
 	find . -name '*.shd.mat'  -exec rm -r {} +


### PR DESCRIPTION
The clean target's find commands for *.png and *.eps were unscoped
and deleted tracked figures under publications/ (logo, fig assets).
Exclude that directory so clean only removes generated build output.

https://claude.ai/code/session_018yqNJgg4c8pQe8RTV7VpGd